### PR TITLE
Add interface for multi-encoding solution creators

### DIFF
--- a/HeuristicLab.Optimization/3.3/BasicProblems/Interfaces/IMultiEncodingCreator.cs
+++ b/HeuristicLab.Optimization/3.3/BasicProblems/Interfaces/IMultiEncodingCreator.cs
@@ -1,0 +1,28 @@
+﻿#region License Information
+/* HeuristicLab
+ * Copyright (C) Heuristic and Evolutionary Algorithms Laboratory (HEAL)
+ *
+ * This file is part of HeuristicLab.
+ *
+ * HeuristicLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HeuristicLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HeuristicLab. If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using HeuristicLab.Core;
+using HEAL.Attic;
+
+namespace HeuristicLab.Optimization {
+  [StorableType("35295303-4664-4634-6738-634346634632")]
+  public interface IMultiEncodingCreator : ISolutionCreator, IMultiEncodingOperator {  }
+}

--- a/HeuristicLab.Optimization/3.3/BasicProblems/MultiEncoding.cs
+++ b/HeuristicLab.Optimization/3.3/BasicProblems/MultiEncoding.cs
@@ -30,7 +30,7 @@ using HeuristicLab.PluginInfrastructure;
 namespace HeuristicLab.Optimization {
   [Item("MultiEncoding", "Describes a combined encoding consisting of multiple simpler encodings.")]
   [StorableType("359E2173-4D0C-40E5-A2F3-E42E59840345")]
-  public sealed class MultiEncoding : Encoding<MultiEncodingCreator> {
+  public sealed class MultiEncoding : Encoding<IMultiEncodingCreator> {
 
     private readonly List<IEncoding> encodings;
     [Storable]

--- a/HeuristicLab.Optimization/3.3/BasicProblems/Operators/MultiEncodingCreator.cs
+++ b/HeuristicLab.Optimization/3.3/BasicProblems/Operators/MultiEncodingCreator.cs
@@ -29,7 +29,7 @@ using HeuristicLab.Parameters;
 namespace HeuristicLab.Optimization {
   [Item("MultiEncoding Creator", "Contains solution creators that together create a multi-encoding.")]
   [StorableType("E261B506-6F74-4BC4-8164-5ACE20FBC319")]
-  public sealed class MultiEncodingCreator : MultiEncodingOperator<ISolutionCreator>, ISolutionCreator, IStochasticOperator {
+  public sealed class MultiEncodingCreator : MultiEncodingOperator<ISolutionCreator>, IMultiEncodingCreator, IStochasticOperator {
     public ILookupParameter<IRandom> RandomParameter {
       get { return (ILookupParameter<IRandom>)Parameters["Random"]; }
     }

--- a/HeuristicLab.Optimization/3.3/HeuristicLab.Optimization-3.3.csproj
+++ b/HeuristicLab.Optimization/3.3/HeuristicLab.Optimization-3.3.csproj
@@ -127,6 +127,7 @@
     <Compile Include="BasicProblems\Individuals\SingleEncodingIndividual.cs" />
     <Compile Include="BasicProblems\Interfaces\IEncoding.cs" />
     <Compile Include="BasicProblems\Interfaces\IEncodingOperator.cs" />
+    <Compile Include="BasicProblems\Interfaces\IMultiEncodingCreator.cs" />
     <Compile Include="BasicProblems\Interfaces\IMultiEncodingOperator.cs" />
     <Compile Include="BasicProblems\Interfaces\IMultiObjectiveProblemDefinition.cs" />
     <Compile Include="BasicProblems\Interfaces\internal\IMultiObjectiveAnalysisOperator.cs" />


### PR DESCRIPTION
This change adds an interface for multi-encoding solution creators, as otherwise it's not possible to write a custom solution creator for multi-encoded problems.