### PR TITLE
Fix PowerSymbol

### DIFF
--- a/HeuristicLab.Problems.DataAnalysis.Symbolic/3.4/Converters/DerivativeCalculator.cs
+++ b/HeuristicLab.Problems.DataAnalysis.Symbolic/3.4/Converters/DerivativeCalculator.cs
@@ -156,7 +156,7 @@ namespace HeuristicLab.Problems.DataAnalysis.Symbolic {
           var newPower = (ISymbolicExpressionTreeNode)branch.Clone();
           var f = (ISymbolicExpressionTreeNode)newPower.GetSubtree(0).Clone();
           var newExponent = (NumberTreeNode)numberSy.CreateTreeNode();
-          newExponent.Value = ((NumberTreeNode)newPower.GetSubtree(1)).Value - 1;
+          newExponent.Value = ((INumericTreeNode)newPower.GetSubtree(1)).Value - 1;
           newPower.RemoveSubtree(1);
           newPower.AddSubtree(newExponent);
           return Product(Product(CreateNumber(exponent.Value), newPower), Derive(f, variableName));


### PR DESCRIPTION
Fixed cast of exponent for PowerSymbol in DerivativeCalculator. 
Due to the fact that we only support the case when the exponent is a constant integer in the derivate calculator, it's not possible to cast the exponent to a number symbol.