### PR TITLE
Algorithm Problem Backchannel 

### DIFF
--- a/HeuristicLab.Clients.OKB/3.3/RunCreation/OKBProblem.cs
+++ b/HeuristicLab.Clients.OKB/3.3/RunCreation/OKBProblem.cs
@@ -120,6 +120,9 @@ namespace HeuristicLab.Clients.OKB.RunCreation {
     }
 
     public IEnumerable<IParameterizedItem> ExecutionContextItems { get { return new[] { this }; } }
+    public void RegisterAlgorithmEvents(IAlgorithm algorithm) {}
+
+    public void DeregisterAlgorithmEvents(IAlgorithm algorithm) {}
 
     #region Persistence Properties
     [Storable(Name = "ProblemId")]

--- a/HeuristicLab.Optimization/3.3/Algorithms/Algorithm.cs
+++ b/HeuristicLab.Optimization/3.3/Algorithms/Algorithm.cs
@@ -85,9 +85,15 @@ namespace HeuristicLab.Optimization {
       set {
         if (problem != value) {
           if ((value != null) && !ProblemType.IsInstanceOfType(value)) throw new ArgumentException("Invalid problem type.");
-          if (problem != null) DeregisterProblemEvents();
+          if (problem != null) {
+            DeregisterProblemEvents();
+            problem.DeregisterAlgorithmEvents(this);
+          }
           problem = value;
-          if (problem != null) RegisterProblemEvents();
+          if (problem != null) {
+            RegisterProblemEvents();
+            problem.RegisterAlgorithmEvents(this);
+          }
           OnProblemChanged();
           Prepare();
         }

--- a/HeuristicLab.Optimization/3.3/Interfaces/IProblem.cs
+++ b/HeuristicLab.Optimization/3.3/Interfaces/IProblem.cs
@@ -31,10 +31,13 @@ namespace HeuristicLab.Optimization {
   /// </summary>
   public interface IProblem : IParameterizedNamedItem {
     IEnumerable<IItem> Operators { get; }
-
-
     IEnumerable<IParameterizedItem> ExecutionContextItems { get; }
+
+    void RegisterAlgorithmEvents(IAlgorithm algorithm);
+    void DeregisterAlgorithmEvents(IAlgorithm algorithm);
+
     event EventHandler OperatorsChanged;
     event EventHandler Reset;
+
   }
 }

--- a/HeuristicLab.Optimization/3.3/Problems/Problem.cs
+++ b/HeuristicLab.Optimization/3.3/Problems/Problem.cs
@@ -150,6 +150,10 @@ namespace HeuristicLab.Optimization {
       if (handler != null)
         handler(this, EventArgs.Empty);
     }
+    
+    public virtual void RegisterAlgorithmEvents(IAlgorithm algorithm) { }
+
+    public virtual void DeregisterAlgorithmEvents(IAlgorithm algorithm) { }
     #endregion
   }
 }

--- a/HeuristicLab.Optimization/3.3/Problems/UserDefinedProblem.cs
+++ b/HeuristicLab.Optimization/3.3/Problems/UserDefinedProblem.cs
@@ -118,6 +118,11 @@ namespace HeuristicLab.Optimization {
     public IEnumerable<IParameterizedItem> ExecutionContextItems {
       get { yield return this; }
     }
+
+    public void RegisterAlgorithmEvents(IAlgorithm algorithm) { }
+
+    public void DeregisterAlgorithmEvents(IAlgorithm algorithm) { }
+
     #endregion
 
     [StorableConstructor]

--- a/HeuristicLab.Tests/HeuristicLab.Optimization-3.4/AlgorithmEventsTest.cs
+++ b/HeuristicLab.Tests/HeuristicLab.Optimization-3.4/AlgorithmEventsTest.cs
@@ -1,0 +1,68 @@
+﻿#region License Information
+/* HeuristicLab
+ * Copyright (C) Heuristic and Evolutionary Algorithms Laboratory (HEAL)
+ *
+ * This file is part of HeuristicLab.
+ *
+ * HeuristicLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HeuristicLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HeuristicLab. If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System.Threading;
+using HeuristicLab.Algorithms.GeneticAlgorithm;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HeuristicLab.Optimization.Tests {
+  [TestClass()]
+  public class AlgorithmEventsTest {
+    /// <summary>
+    ///A test for EvaluateFunction
+    ///</summary>
+    [TestMethod]
+    [TestCategory("Problems.Optimization")]
+    [TestProperty("Time", "short")]
+    public void ExecutionStateEventRegistrationTest() {
+      var alg = new EventTestAlgorithm();
+      var problem = new EventTestProblem();
+      Assert.AreEqual(0,problem.State);
+      alg.Problem = problem;
+      Assert.AreEqual(1,problem.State);
+      alg.Prepare();
+      Assert.AreEqual(1,problem.State);
+      alg.Start(CancellationToken.None);
+      Assert.AreEqual(4,problem.State);
+    }
+
+    /// <summary>
+    ///A test for EvaluateFunction
+    ///</summary>
+    [TestMethod]
+    [TestCategory("Problems.Optimization")]
+    [TestProperty("Time", "short")]
+    public void ExecutionStateEventDeregistrationTest() {
+      var alg = new EventTestAlgorithm();
+      var problem = new EventTestProblem();
+      var problem2 = new EventTestProblem();
+
+      Assert.AreEqual(0,problem.State);
+      alg.Problem = problem;
+      alg.Problem = problem2;
+      Assert.AreEqual(1,problem.State);
+      alg.Prepare();
+      Assert.AreEqual(1,problem.State);
+      alg.Start(CancellationToken.None);
+      Assert.AreEqual(1,problem.State);
+    }
+  }
+}

--- a/HeuristicLab.Tests/HeuristicLab.Optimization-3.4/EventTestAlgorithm.cs
+++ b/HeuristicLab.Tests/HeuristicLab.Optimization-3.4/EventTestAlgorithm.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using HeuristicLab.Common;
+using HeuristicLab.Optimization;
+
+namespace HeuristicLab.Optimization.Tests {
+  public  class EventTestAlgorithm: BasicAlgorithm {
+
+    public EventTestAlgorithm() {
+
+    } 
+    public EventTestAlgorithm(EventTestAlgorithm original, Cloner cloner): base(original, cloner) { }
+
+    public override IDeepCloneable Clone(Cloner cloner) {
+      return new EventTestAlgorithm(this, cloner);
+    }
+
+    protected override void Run(CancellationToken cancellationToken) {
+      //Do nothing
+    }
+
+    public override bool SupportsPause => false;
+  }
+}

--- a/HeuristicLab.Tests/HeuristicLab.Optimization-3.4/EventTestProblem.cs
+++ b/HeuristicLab.Tests/HeuristicLab.Optimization-3.4/EventTestProblem.cs
@@ -1,0 +1,91 @@
+﻿#region License Information
+/* HeuristicLab
+ * Copyright (C) Heuristic and Evolutionary Algorithms Laboratory (HEAL)
+ *
+ * This file is part of HeuristicLab.
+ *
+ * HeuristicLab is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * HeuristicLab is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with HeuristicLab. If not, see <http://www.gnu.org/licenses/>.
+ */
+#endregion
+
+using System;
+using HeuristicLab.Common;
+using HeuristicLab.Core;
+using HeuristicLab.Encodings.RealVectorEncoding;
+using HeuristicLab.Optimization;
+
+namespace HeuristicLab.Optimization.Tests{
+  internal class EventTestProblem : SingleObjectiveBasicProblem<RealVectorEncoding> {
+
+  public int State {
+    get;
+    private set;
+  }
+
+  public EventTestProblem() {
+    State = 0;
+  }
+
+  public EventTestProblem(EventTestProblem original, Cloner cloner) : base(original, cloner) {
+    State = original.State;
+  }
+
+  public override IDeepCloneable Clone(Cloner cloner) {
+    return new EventTestProblem();
+  }
+
+  public override void RegisterAlgorithmEvents(IAlgorithm algorithm) {
+    base.RegisterAlgorithmEvents(algorithm);
+    algorithm.ExceptionOccurred += OnAlgorithmException;
+    algorithm.ExecutionStateChanged += OnAlgorithmExecutionStateChanged;
+  }
+
+  private void OnAlgorithmExecutionStateChanged(object sender, EventArgs e) {
+    var alg = (IAlgorithm)sender;
+    if (State < 0) return;
+    switch (alg.ExecutionState) {
+      case ExecutionState.Prepared:
+        State = 1;
+        break;
+      case ExecutionState.Started:
+        State = 2;
+        break;
+      case ExecutionState.Paused:
+        State = 3;
+        break;
+      case ExecutionState.Stopped:
+        State = 4;
+        break;
+      default:
+        throw new ArgumentOutOfRangeException();
+    }
+  }
+
+  private void OnAlgorithmException(object sender, EventArgs<Exception> e) {
+    State = -1;
+  }
+
+  public override void DeregisterAlgorithmEvents(IAlgorithm algorithm) {
+    base.RegisterAlgorithmEvents(algorithm);
+    algorithm.ExceptionOccurred -= OnAlgorithmException;
+    algorithm.ExecutionStateChanged -= OnAlgorithmExecutionStateChanged;
+  }
+
+  public override double Evaluate(Individual individual, IRandom random) {
+    return State;
+  }
+
+  public override bool Maximization => false;
+  }
+}

--- a/HeuristicLab.Tests/HeuristicLab.Tests.csproj
+++ b/HeuristicLab.Tests/HeuristicLab.Tests.csproj
@@ -595,6 +595,9 @@
     <Compile Include="HeuristicLab.IGraph\IGraphWrappersGraphTest.cs" />
     <Compile Include="HeuristicLab.IGraph\IGraphWrappersMatrixTest.cs" />
     <Compile Include="HeuristicLab.IGraph\IGraphWrappersVectorTest.cs" />
+    <Compile Include="HeuristicLab.Optimization-3.4\AlgorithmEventsTest.cs" />
+    <Compile Include="HeuristicLab.Optimization-3.4\EventTestAlgorithm.cs" />
+    <Compile Include="HeuristicLab.Optimization-3.4\EventTestProblem.cs" />
     <Compile Include="HeuristicLab.Persistence-3.3\StorableAttributeTests.cs" />
     <Compile Include="HeuristicLab.Persistence-3.3\UseCases.cs" />
     <Compile Include="HeuristicLab.Persistence.Attic\PersistenceConsistencyChecks.cs" />
@@ -728,6 +731,7 @@
       <Private>False</Private>
     </Reference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
For some stateful (e.g. dynamic) problems it is desirable to have more information about the current state of the algorithm than the current `IStatefulItem`-Interface. I extended `IProblem` with the ability to listen to `IAlgorithm`-events.