### PR TITLE
Add clear method for sym reg grammar

### DIFF
--- a/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/EmptySymbolicExpressionTreeGrammar.cs
+++ b/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/EmptySymbolicExpressionTreeGrammar.cs
@@ -103,6 +103,8 @@ namespace HeuristicLab.Encodings.SymbolicExpressionTreeEncoding {
     public void AddAllowedChildSymbol(ISymbol parent, ISymbol child, int argumentIndex) { throw new NotSupportedException(); }
     public void RemoveAllowedChildSymbol(ISymbol parent, ISymbol child) { throw new NotSupportedException(); }
     public void RemoveAllowedChildSymbol(ISymbol parent, ISymbol child, int argumentIndex) { throw new NotSupportedException(); }
+    public void ClearAllowedChildSymbols(ISymbol parent) { throw new NotSupportedException(); }
+    public void ClearAllAllowedChildSymbols() { throw new NotSupportedException(); }
     public void SetSubtreeCount(ISymbol symbol, int minimumSubtreeCount, int maximumSubtreeCount) { throw new NotSupportedException(); }
 
 

--- a/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/SymbolicExpressionGrammar.cs
+++ b/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/SymbolicExpressionGrammar.cs
@@ -210,6 +210,15 @@ namespace HeuristicLab.Encodings.SymbolicExpressionTreeEncoding {
       base.RemoveAllowedChildSymbol(parent, child, argumentIndex);
     }
 
+    public sealed override void ClearAllowedChildSymbols(ISymbol parent) {
+      if (ReadOnly) throw new InvalidOperationException();
+      base.ClearAllowedChildSymbols(parent);
+    }
+    public sealed override void ClearAllAllowedChildSymbols() {
+      if (ReadOnly) throw new InvalidOperationException();
+      base.ClearAllAllowedChildSymbols();
+    }
+
     public sealed override void SetSubtreeCount(ISymbol symbol, int minimumSubtreeCount, int maximumSubtreeCount) {
       if (ReadOnly) throw new InvalidOperationException();
       base.SetSubtreeCount(symbol, minimumSubtreeCount, maximumSubtreeCount);

--- a/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/SymbolicExpressionGrammarBase.cs
+++ b/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/SymbolicExpressionGrammarBase.cs
@@ -281,6 +281,32 @@ namespace HeuristicLab.Encodings.SymbolicExpressionTreeEncoding {
       }
     }
 
+    public virtual void ClearAllowedChildSymbols(ISymbol parent) {
+      bool changed = false;
+      if (allowedChildSymbols.TryGetValue(parent.Name, out var childSymbols)) {
+        changed |= childSymbols.Count > 0;
+        childSymbols.Clear();
+      }
+
+      for (int argumentIndex = 0; argumentIndex < GetMaximumSubtreeCount(parent); argumentIndex++) {
+        var key = Tuple.Create(parent.Name, argumentIndex);
+        if (allowedChildSymbolsPerIndex.TryGetValue(key, out childSymbols)) {
+          changed |= childSymbols.Count > 0;
+          childSymbols.Clear();
+        }
+      }
+
+      if (changed) {
+        ClearCaches();
+        OnChanged();
+      }
+    }
+
+    public virtual void ClearAllAllowedChildSymbols() {
+      foreach(var symbol in Symbols)
+        ClearAllowedChildSymbols(symbol);
+    }
+
     public virtual void SetSubtreeCount(ISymbol symbol, int minimumSubtreeCount, int maximumSubtreeCount) {
       var symbols = symbol.Flatten().Where(s => !(s is GroupSymbol));
       if (symbols.Any(s => s.MinimumArity > minimumSubtreeCount)) throw new ArgumentException("Invalid minimum subtree count " + minimumSubtreeCount + " for " + symbol);

--- a/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/SymbolicExpressionGrammarBase.cs
+++ b/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Grammars/SymbolicExpressionGrammarBase.cs
@@ -282,6 +282,25 @@ namespace HeuristicLab.Encodings.SymbolicExpressionTreeEncoding {
     }
 
     public virtual void ClearAllowedChildSymbols(ISymbol parent) {
+      var changed = ClearAllowedChildSymbolsDictionaries(parent);
+      if (changed) {
+        ClearCaches();
+        OnChanged();
+      }
+    }
+
+    public virtual void ClearAllAllowedChildSymbols() {
+      bool changed = false;
+      foreach (var symbol in Symbols)
+        changed |= ClearAllowedChildSymbolsDictionaries(symbol);
+
+      if (changed) {
+        ClearCaches();
+        OnChanged();
+      }
+    }
+
+    private bool ClearAllowedChildSymbolsDictionaries(ISymbol parent) {
       bool changed = false;
       if (allowedChildSymbols.TryGetValue(parent.Name, out var childSymbols)) {
         changed |= childSymbols.Count > 0;
@@ -295,16 +314,7 @@ namespace HeuristicLab.Encodings.SymbolicExpressionTreeEncoding {
           childSymbols.Clear();
         }
       }
-
-      if (changed) {
-        ClearCaches();
-        OnChanged();
-      }
-    }
-
-    public virtual void ClearAllAllowedChildSymbols() {
-      foreach(var symbol in Symbols)
-        ClearAllowedChildSymbols(symbol);
+      return changed;
     }
 
     public virtual void SetSubtreeCount(ISymbol symbol, int minimumSubtreeCount, int maximumSubtreeCount) {

--- a/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Interfaces/ISymbolicExpressionGrammarBase.cs
+++ b/HeuristicLab.Encodings.SymbolicExpressionTreeEncoding/3.4/Interfaces/ISymbolicExpressionGrammarBase.cs
@@ -45,6 +45,8 @@ namespace HeuristicLab.Encodings.SymbolicExpressionTreeEncoding {
     void AddAllowedChildSymbol(ISymbol parent, ISymbol child, int argumentIndex);
     void RemoveAllowedChildSymbol(ISymbol parent, ISymbol child);
     void RemoveAllowedChildSymbol(ISymbol parent, ISymbol child, int argumentIndex);
+    void ClearAllowedChildSymbols(ISymbol parent);
+    void ClearAllAllowedChildSymbols();
 
 
     int GetMinimumSubtreeCount(ISymbol symbol);

--- a/HeuristicLab.Problems.DataAnalysis.Symbolic/3.4/Symbols/SubFunctionTreeNode.cs
+++ b/HeuristicLab.Problems.DataAnalysis.Symbolic/3.4/Symbols/SubFunctionTreeNode.cs
@@ -26,7 +26,7 @@ namespace HeuristicLab.Problems.DataAnalysis.Symbolic {
 
     private SubFunctionTreeNode(SubFunctionTreeNode original, Cloner cloner) : base(original, cloner) {
       Arguments = original.Arguments;
-      Name = (string)original.Name.Clone();
+      Name = original.Name;
     }
     #endregion
 


### PR DESCRIPTION
Adds the following clear methods in ```ISymbolicExpressionGrammarBase``` to clear allowed child symbols:
- ```ClearAllowedChildSymbols(ISymbol parent)```: clears all allowed child symbols for a specific parent symbol
- ```ClearAllAllowedChildSymbols()```: clears all allowed childs symbols for all symbols

The methods are implemented/overwritten in:
- ```SymbolicExpressionGrammarBase```
- ```SymbolicExpressionGrammar```
- ```EmptySymbolicExpressionTreeGrammar```
